### PR TITLE
Disable generation of user lists for Uploads lists of mitx and ocw

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+Open Video Data
+---
+
+This repository stores configuration data for MIT Open's video ingestion.
+
+
+#### YouTube
+
+In order to add a new YouTube channel, create a file with the extention `.yaml` in the `youtube/` directory. The format of the file should follow this structure:
+
+```yaml
+---
+channel_id: CHANNEL_ID
+offered_by: OCW  # optional, defaults to none
+playlists:  # may include one or more playlists
+  - id: PLAYLIST_ID1
+    create_user_list: false  # optional field, defaults to yes
+  - id: PLAYLIST_ID2
+```
+
+**NOTE:** the comments (the part after `#`) in the example above are purely documentative, you may remove them or leave them in your actual configuration file.

--- a/youtube/MITx.yaml
+++ b/youtube/MITx.yaml
@@ -3,3 +3,4 @@ channel_id: UCTBMWu8yshnAmpzR3MoJFtw
 offered_by: MITx
 playlists:
   - id: UUTBMWu8yshnAmpzR3MoJFtw
+    create_user_list: false

--- a/youtube/OCW.yaml
+++ b/youtube/OCW.yaml
@@ -3,3 +3,4 @@ channel_id: UCEBb1b_L6zDS3xTUrIALZOw
 offered_by: OCW
 playlists:
   - id: UUEBb1b_L6zDS3xTUrIALZOw
+    create_user_list: false


### PR DESCRIPTION
- Adds `create_user_list: no` to OCW and MITx upload playlists so that we don't generate those
- Adds a minimal README documenting the file format